### PR TITLE
Fix .gitignore, CS-Fixer config, and test bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 .idea
+.claude
 
 ###> symfony/framework-bundle ###
 /.env.local
 /.env.local.php
 /.env.*.local
 /config/secrets/prod/prod.decrypt.private.php
+/config/reference.php
 /public/bundles/
 /var/
 /vendor/
@@ -14,7 +16,6 @@
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###
-.php-cs-fixer.cache
 
 ###> phpunit/phpunit ###
 /phpunit.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,6 +3,7 @@
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
     ->exclude('var')
+    ->notPath('config/reference.php')
 ;
 
 return (new PhpCsFixer\Config())

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,6 @@ if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
 
-if ($_SERVER['APP_DEBUG']) {
+if ($_SERVER['APP_DEBUG'] ?? false) {
     umask(0000);
 }


### PR DESCRIPTION
## Summary
- Add `.claude/` and `config/reference.php` (auto-generated) to `.gitignore`
- Remove duplicate `.php-cs-fixer.cache` entry from `.gitignore`
- Exclude `config/reference.php` from PHP-CS-Fixer (auto-generated, not committed)
- Guard `$_SERVER['APP_DEBUG']` with `?? false` in `tests/bootstrap.php` to prevent undefined index warning

## Test plan
- [x] `vendor/bin/phpunit` → 29 tests, 49 assertions, all green
- [x] `vendor/bin/phpstan analyse` → 0 errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run` → 0 violations (previously 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)