### PR TITLE
[Mittel] Härtung: HTTP-Timeout und defensives XML-Parsing

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,6 +1,10 @@
 framework:
     secret: '%env(APP_SECRET)%'
     http_method_override: false
+    http_client:
+        default_options:
+            timeout: 10
+            max_duration: 30
     php_errors:
         log: true
 

--- a/src/SourceFetcher/SourceFetcher.php
+++ b/src/SourceFetcher/SourceFetcher.php
@@ -23,7 +23,13 @@ class SourceFetcher implements SourceFetcherInterface
         $response = $this->httpClient->request('GET', self::DATA_URI);
         $xmlFile = $response->getContent();
 
-        $simpleXml = new \SimpleXMLElement($xmlFile);
+        if ('' === trim($xmlFile)) {
+            return null;
+        }
+
+        // LIBXML_NONET verhindert das Laden externer Entities/DTDs über das Netz
+        // (defensive Härtung gegen XXE, unabhängig von libxml-Defaults).
+        $simpleXml = new \SimpleXMLElement($xmlFile, LIBXML_NONET);
 
         $resultList = $this->parseXmlFile($simpleXml);
 


### PR DESCRIPTION
Adressiert den Härtungs-Teil von #38 (Dependency-Updates separat — siehe Hinweis).

## Änderungen
- **`config/packages/framework.yaml`**: `http_client.default_options.timeout: 10` + `max_duration: 30`. Bisher ohne Timeout — bei hängendem NOAA-Upstream blockiert der Cron-Job unbegrenzt.
- **`SourceFetcher`**: `new \SimpleXMLElement($xml, LIBXML_NONET)` statt ohne Flags — verhindert das Laden externer Entities/DTDs über das Netz (defensive XXE-Härtung, unabhängig von libxml-Defaults). Zusätzlich Guard gegen leere Antwort (sauberes `null` statt Exception).

## Verifikation
`php -l` ok, Test-Suite grün (29 Tests). Die vorhandenen Tests parsen valides RSS-XML und laufen unverändert.

## Hinweis (separat)
Die Symfony-Dependency-CVEs aus #38 erfordern denselben koordinierten Symfony-8.1-/PHPStan-Schritt wie luft-app#525 und sind hier nicht enthalten.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)