### PR TITLE
Harden NOAA fetch value extraction (#40)

### DIFF
--- a/src/SourceFetcher/SourceFetcher.php
+++ b/src/SourceFetcher/SourceFetcher.php
@@ -34,7 +34,12 @@ class SourceFetcher implements SourceFetcherInterface
         $lastValueDateTimeString = array_key_last($resultList);
         $lastCo2Value = $resultList[$lastValueDateTimeString];
 
-        return $this->createValue($lastCo2Value, new \DateTime($lastValueDateTimeString));
+        // The feed reports plain dates without a timezone; anchor them to UTC
+        // explicitly so the pushed timestamp does not depend on the server's
+        // default timezone.
+        $dateTime = new \DateTime($lastValueDateTimeString, new \DateTimeZone('UTC'));
+
+        return $this->createValue($lastCo2Value, $dateTime);
     }
 
     private function createValue(float $co2Value, \DateTime $dateTime): Value
@@ -48,7 +53,16 @@ class SourceFetcher implements SourceFetcherInterface
         return $value;
     }
 
-    /** @return array<string, float> */
+    /**
+     * Builds a map of `Y-m-d` GUID => CO2 value from the RSS items.
+     *
+     * Only weekly items with a full year-month-day GUID (e.g. `2026-6-21`) are
+     * considered. Monthly aggregate items, whose GUID has only two parts
+     * (e.g. `2026-5`), are intentionally skipped so that the pushed value is
+     * always the most recent weekly reading.
+     *
+     * @return array<string, float>
+     */
     private function parseXmlFile(\SimpleXMLElement $xmlRoot): array
     {
         $resultList = [];
@@ -79,8 +93,12 @@ class SourceFetcher implements SourceFetcherInterface
 
     private function fetchCo2ValueFromString(string $description): ?float
     {
-        if (preg_match('/\d{3,}\.\d{1,2}/', $description, $matches)) {
-            return (float) $matches[0];
+        // Anchor on the "ppm" unit and a word boundary so that unrelated numbers
+        // in the description are ignored and a value is never sliced out of a
+        // longer number (e.g. `430.85` out of `1430.85`). The first match is the
+        // current weekly reading in the live feed.
+        if (preg_match('/\b(\d{3,4}\.\d{1,2})\s*ppm/i', $description, $matches)) {
+            return (float) $matches[1];
         }
 
         return null;

--- a/tests/SourceFetcher/SourceFetcherTest.php
+++ b/tests/SourceFetcher/SourceFetcherTest.php
@@ -364,6 +364,48 @@ XML;
         yield 'iso datetime' => ['2024-01-15T12:00:00'];
     }
 
+    public function testFetchIgnoresNumbersWithoutPpmUnit(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <guid>2024-3-15</guid>
+      <description>Station 421.99, temperature 12.5 C, CO2 430.12 ppm</description>
+    </item>
+  </channel>
+</rss>
+XML;
+
+        $fetcher = $this->createFetcher($xml);
+        $value = $fetcher->fetch();
+
+        self::assertNotNull($value);
+        self::assertSame(430.12, $value->getValue());
+    }
+
+    public function testFetchAssignsUtcTimezoneToDateTime(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <guid>2024-7-4</guid>
+      <description>CO2: 419.80 ppm</description>
+    </item>
+  </channel>
+</rss>
+XML;
+
+        $fetcher = $this->createFetcher($xml);
+        $value = $fetcher->fetch();
+
+        self::assertNotNull($value);
+        self::assertSame('UTC', $value->getDateTime()->getTimezone()->getName());
+    }
+
     private function createFetcher(string $responseBody): SourceFetcher
     {
         $response = new MockResponse($responseBody);


### PR DESCRIPTION
Addresses the remaining hardening items from #40. Most of the issue was already resolved on current `main` (updated `DATA_URI`, `null`-return instead of a fabricated `0.0`, `Command::FAILURE` on empty fetch, `HttpClient` injection). This PR covers what was left:

## Changes
- **Regex hardening** (`SourceFetcher::fetchCo2ValueFromString`): anchor extraction on the `ppm` unit with a word boundary (`/\b(\d{3,4}\.\d{1,2})\s*ppm/i`), so unrelated numbers are ignored and a value can never be sliced out of a longer number (e.g. `430.85` out of `1430.85`).
- **UTC timestamp**: parse the feed date as explicit `UTC` instead of the server default timezone.
- **Documentation**: comment explaining that monthly aggregate GUIDs (e.g. `2026-5`) are intentionally filtered so only the latest weekly reading is pushed.
- **Tests**: added coverage for ppm-anchoring and the UTC timezone.

## Deliberately not implemented
- **Reject values outside 300–600 ppm**: this directly contradicts the existing `testFetchHandlesCo2ValuesAbove999` test (which expects `1050.25 ppm` to be accepted). Left for maintainer decision — happy to add it and adjust that test if you want the plausibility gate.
- **`\DateTimeImmutable`**: blocked by the `luft-model` contract `Value::setDateTime(\DateTime)`. The timezone bug (the real concern) is fixed regardless.

## Verification
`vendor/bin/phpunit` (31 tests, 53 assertions), `vendor/bin/phpstan analyse`, and `vendor/bin/php-cs-fixer fix --dry-run --diff` all pass locally.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)