### PR TITLE
Harden NOAA XML parsing and bound the HTTP fetch (#38)

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -3,6 +3,11 @@ framework:
     http_method_override: false
     php_errors:
         log: true
+    http_client:
+        default_options:
+            # Bound the cron fetch so a hanging NOAA upstream cannot block the job.
+            timeout: 10
+            max_duration: 30
 
 when@test:
     framework:

--- a/src/SourceFetcher/SourceFetcher.php
+++ b/src/SourceFetcher/SourceFetcher.php
@@ -23,7 +23,17 @@ class SourceFetcher implements SourceFetcherInterface
         $response = $this->httpClient->request('GET', self::DATA_URI);
         $xmlFile = $response->getContent();
 
-        $simpleXml = new \SimpleXMLElement($xmlFile);
+        if ('' === trim($xmlFile)) {
+            throw new \RuntimeException('NOAA feed returned an empty response.');
+        }
+
+        // Reject DOCTYPE declarations outright: combined with LIBXML_NONET this keeps
+        // parsing safe against XXE/entity-expansion regardless of future libxml defaults.
+        if (str_contains($xmlFile, '<!DOCTYPE')) {
+            throw new \RuntimeException('NOAA feed contains a DOCTYPE declaration; refusing to parse.');
+        }
+
+        $simpleXml = new \SimpleXMLElement($xmlFile, LIBXML_NONET);
 
         $resultList = $this->parseXmlFile($simpleXml);
 

--- a/tests/SourceFetcher/SourceFetcherTest.php
+++ b/tests/SourceFetcher/SourceFetcherTest.php
@@ -289,6 +289,37 @@ XML;
         $fetcher->fetch();
     }
 
+    public function testFetchThrowsOnEmptyResponse(): void
+    {
+        $fetcher = $this->createFetcher('   ');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('empty response');
+        $fetcher->fetch();
+    }
+
+    public function testFetchRejectsDoctypeDeclaration(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rss [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<rss version="2.0">
+  <channel>
+    <item>
+      <guid>2024-3-15</guid>
+      <description>CO2: &xxe; 421.37 ppm</description>
+    </item>
+  </channel>
+</rss>
+XML;
+
+        $fetcher = $this->createFetcher($xml);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('DOCTYPE');
+        $fetcher->fetch();
+    }
+
     public function testFetchIgnoresItemsWithEmptyGuid(): void
     {
         $xml = <<<'XML'


### PR DESCRIPTION
Implements the transport-hardening items from #38 against current `main`.

## Changes
- **Defensive XML parsing** (`SourceFetcher::fetch`): reject an empty/whitespace HTTP body before parsing, refuse any payload containing a `<!DOCTYPE` declaration, and pass `LIBXML_NONET` to `SimpleXMLElement`. Together these keep the parser safe against XXE / external-entity and entity-expansion attacks regardless of the runtime libxml defaults (as the issue notes, the current libxml is not exploitable, but the safety then rests on a default rather than on code).
- **HTTP timeout**: `framework.http_client.default_options.timeout: 10` and `max_duration: 30`, so a hanging NOAA upstream cannot block the cron job.
- **Tests**: added coverage for the empty-response guard and DOCTYPE rejection.

## Deliberately not implemented here
- **Dependency updates (2026 CVEs) + `composer audit` in CI**: delivered by #41 (dependency ticket), which moves the lock to Symfony 8.1.1 and adds the audit gate. Kept out of this branch to avoid a duplicate `composer.lock` change — this PR is purely code/config hardening.

## Verification
Local, all green:
- `vendor/bin/phpunit` -> 31 tests, 53 assertions (2 new)
- `vendor/bin/phpstan analyse` -> no errors
- `vendor/bin/php-cs-fixer fix --dry-run --diff` -> clean
- `php bin/console cache:clear` -> container compiles with the new `http_client` config

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)